### PR TITLE
Remove invalid entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.9",
   "description": "The Helika SDK is for developers to be able to make API calls to the Helika DEV and PROD endpoints.",
   "main": "dist/index.js",
-  "module": "dist/index.m.js",
-  "unpkg": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
We had an error when trying to add the sdk to our vite app because it was trying to load the module defined on the `package.json`. However that file doesn't exist on version 0.2.9.

This PR removes those entrypoints, which solves that problem. Another option would be to actually generate the removed entrypoints